### PR TITLE
Add program shutdown timeout

### DIFF
--- a/internal/crane/run.go
+++ b/internal/crane/run.go
@@ -156,7 +156,7 @@ func createRunFlow(
 			if runningProcess == nil {
 				return nil
 			}
-			log.Printf("stopping running process...")
+			log.Printf("stopping running process (timeout: %s)...", shutdownTimeout)
 			shutdownCtx, shutdownFunc := context.WithTimeout(ctx, shutdownTimeout)
 			defer shutdownFunc()
 			if err := runningProcess.Stop(shutdownCtx); err != nil {

--- a/internal/crane/run.go
+++ b/internal/crane/run.go
@@ -14,12 +14,13 @@ import (
 )
 
 type Settings struct {
-	Verbose      bool
-	IncluedPaths []string
-	ExcludePaths []string
-	ExcludeGlobs []string
-	RunDir       string
-	CachedBuild  string
+	Verbose         bool
+	IncluedPaths    []string
+	ExcludePaths    []string
+	ExcludeGlobs    []string
+	RunDir          string
+	CachedBuild     string
+	ShutdownTimeout time.Duration
 }
 
 func Run(ctx context.Context, settings Settings) error {
@@ -95,6 +96,7 @@ func Run(ctx context.Context, settings Settings) error {
 		groupCtx,
 		runner,
 		buildEventQueue,
+		settings.ShutdownTimeout,
 	))
 
 	return group.Wait()
@@ -130,6 +132,7 @@ func createRunFlow(
 	ctx context.Context,
 	runner *project.Runner,
 	buildEventQueue events.BuildQueue,
+	shutdownTimeout time.Duration,
 ) func() error {
 
 	return func() error {
@@ -154,7 +157,9 @@ func createRunFlow(
 				return nil
 			}
 			log.Printf("stopping running process...")
-			if err := runningProcess.Stop(); err != nil {
+			shutdownCtx, shutdownFunc := context.WithTimeout(ctx, shutdownTimeout)
+			defer shutdownFunc()
+			if err := runningProcess.Stop(shutdownCtx); err != nil {
 				return fmt.Errorf("failed to stop process: %w", err)
 			}
 			log.Printf("successfully stopped running process.")

--- a/internal/project/runner.go
+++ b/internal/project/runner.go
@@ -20,22 +20,37 @@ func (r *Runner) Run(ctx context.Context, path string) (*Process, error) {
 	output := logWriter{
 		logger: log.New(log.Writer(), "[program]: ", log.Ltime|log.Lmsgprefix),
 	}
-	cmd := exec.CommandContext(ctx, path)
+
+	runCtx, killFunc := context.WithCancel(ctx)
+	cmd := exec.CommandContext(runCtx, path)
 	cmd.Stdout = output
 	cmd.Stderr = output
 	if err := cmd.Start(); err != nil {
+		killFunc() // otherwise linter complains
 		return nil, fmt.Errorf("failed to start program: %w", err)
 	}
 	return &Process{
 		process: cmd.Process,
+		kill:    killFunc,
 	}, nil
 }
 
 type Process struct {
 	process *os.Process
+	kill    func()
 }
 
-func (p *Process) Stop() error {
+func (p *Process) Stop(ctx context.Context) error {
+	stopped := make(chan struct{})
+	defer close(stopped)
+	go func() {
+		select {
+		case <-ctx.Done():
+			p.kill()
+		case <-stopped:
+		}
+	}()
+
 	if err := p.process.Signal(syscall.SIGTERM); err != nil {
 		return fmt.Errorf("failed to send sigterm signal to program: %w", err)
 	}

--- a/internal/project/runner.go
+++ b/internal/project/runner.go
@@ -46,6 +46,7 @@ func (p *Process) Stop(ctx context.Context) error {
 	go func() {
 		select {
 		case <-ctx.Done():
+			log.Println("killing program forcefully as it failed to shutdown gracefully")
 			p.kill()
 		case <-stopped:
 		}

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/mokiat/gocrane/internal/crane"
 	"github.com/urfave/cli/v2"
@@ -58,15 +59,22 @@ func main() {
 				Aliases: []string{"c"},
 				EnvVars: []string{"GOCRANE_CACHE"},
 			},
+			&cli.DurationFlag{
+				Name:    "shutdown-timeout",
+				Usage:   "amount of time to wait for program to exit gracefully",
+				Value:   5 * time.Second,
+				EnvVars: []string{"GOCRANE_SHUTDOWN_TIMEOUT"},
+			},
 		},
 		Action: func(c *cli.Context) error {
 			return crane.Run(c.Context, crane.Settings{
-				Verbose:      c.Bool("verbose"),
-				IncluedPaths: c.StringSlice("path"),
-				ExcludePaths: c.StringSlice("exclude"),
-				ExcludeGlobs: c.StringSlice("glob-exclude"),
-				RunDir:       c.String("run"),
-				CachedBuild:  c.String("cache"),
+				Verbose:         c.Bool("verbose"),
+				IncluedPaths:    c.StringSlice("path"),
+				ExcludePaths:    c.StringSlice("exclude"),
+				ExcludeGlobs:    c.StringSlice("glob-exclude"),
+				RunDir:          c.String("run"),
+				CachedBuild:     c.String("cache"),
+				ShutdownTimeout: c.Duration("shutdown-timeout"),
 			})
 		},
 	}


### PR DESCRIPTION
This PR adds the ability to specify a shutdown timeout. When a program is rebuilt and needs to be stopped it will wait at most the specified duration before forcefully killing it. If not specified, a default value of 5 seconds is used.

Fixes #11 

**Edit 01:** 
I have added some logging so that it is clear how long the graceful timeout is and when gocrane kills the program forcefully. This also makes it apparent that when gocrane shutdowns right now, it does not respect the graceful shutdown, as described in #10 . I will probably prepare a separate PR to fix that problem. I think I even have a good idea how to achieve it.