### PR TITLE
support passing arguments to go build

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The tool supports the following flags for more custom configuration:
 * `--run, -r` - Specifies the folder that includes the `main` package to be run.
 * `--cache, -c` - Specifies a pre-build executable to use the first time. This is useful when using `gocrane` with Docker images that have the built executable available to avoid unnecessary initial builds on startup.
 * `--args` - Specifies arguments to pass when starting the built executable.
+* `--build-args` - Specifies arguments to pass to `go build` (when compiling the executable)
 
 By default `gocrane` excludes the following glob patterns:
 

--- a/internal/crane/run.go
+++ b/internal/crane/run.go
@@ -21,6 +21,7 @@ type Settings struct {
 	RunDir          string
 	CachedBuild     string
 	Args            []string
+	BuildArgs       []string
 	ShutdownTimeout time.Duration
 }
 
@@ -45,7 +46,7 @@ func Run(ctx context.Context, settings Settings) error {
 
 	watcher := change.NewWatcher(settings.IncluedPaths, settings.ExcludePaths, settings.ExcludeGlobs, settings.Verbose)
 	batcher := change.NewBatcher(time.Second)
-	builder, err := project.NewBuilder(settings.RunDir)
+	builder, err := project.NewBuilder(settings.RunDir, settings.BuildArgs)
 	if err != nil {
 		return fmt.Errorf("failed to create builder: %w", err)
 	}

--- a/internal/project/builder.go
+++ b/internal/project/builder.go
@@ -12,7 +12,7 @@ import (
 	uuid "github.com/satori/go.uuid"
 )
 
-func NewBuilder(runDir string) (*Builder, error) {
+func NewBuilder(runDir string, args []string) (*Builder, error) {
 	tempDir, err := ioutil.TempDir("", "gocrane-*")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temp directory: %w", err)
@@ -20,12 +20,14 @@ func NewBuilder(runDir string) (*Builder, error) {
 	return &Builder{
 		runDir:  runDir,
 		tempDir: tempDir,
+		args:    args,
 	}, nil
 }
 
 type Builder struct {
 	runDir  string
 	tempDir string
+	args    []string
 }
 
 func (b *Builder) Build(ctx context.Context) (string, error) {
@@ -35,7 +37,10 @@ func (b *Builder) Build(ctx context.Context) (string, error) {
 	output := logWriter{
 		logger: log.New(log.Writer(), "[compiler]: ", log.Ltime|log.Lmsgprefix),
 	}
-	cmd := exec.CommandContext(ctx, "go", "build", "-o", path, "./")
+
+	args := append([]string{"build"}, b.args...)
+	args = append(args, "-o", path, "./")
+	cmd := exec.CommandContext(ctx, "go", args...)
 	cmd.Dir = b.runDir
 	cmd.Stdout = output
 	cmd.Stderr = output

--- a/main.go
+++ b/main.go
@@ -66,6 +66,12 @@ func main() {
 				EnvVars: []string{"GOCRANE_ARGS"},
 				Value:   &flag.ShlexStringSlice{},
 			},
+			&cli.GenericFlag{
+				Name:    "build-args",
+				Usage:   "arguments to use when building the executable",
+				EnvVars: []string{"GOCRANE_BUILD_ARGS"},
+				Value:   &flag.ShlexStringSlice{},
+			},
 			&cli.DurationFlag{
 				Name:    "shutdown-timeout",
 				Usage:   "amount of time to wait for program to exit gracefully",
@@ -82,6 +88,7 @@ func main() {
 				RunDir:          c.String("run"),
 				CachedBuild:     c.String("cache"),
 				Args:            flag.ShlexStrings(c.Generic("args")),
+				BuildArgs:       flag.ShlexStrings(c.Generic("build-args")),
 				ShutdownTimeout: c.Duration("shutdown-timeout"),
 			})
 		},


### PR DESCRIPTION
Add `--build-args` flag, which allows one to specify arguments to be passed to `go build`.

Currently the `Builder` component already passes the `-o` flag, but I have not added any checks to prevent the end user specifying the flag again. I don't think it makes any sense for the `gocrane` users to specify the `-o` flag, thus why I decided to leave this tricky checks.

Updates #3.