### PR TITLE
Fix fake change event

### DIFF
--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -91,10 +91,14 @@ func run(ctx context.Context, cfg runConfig) error {
 			}
 		} else {
 			log.Printf("digest mismatch (%s != %s), will build from scratch.", digest, storedDigest)
-			fakeChangeEvent = &pipeline.ChangeEvent{}
+			fakeChangeEvent = &pipeline.ChangeEvent{
+				Paths: []string{pipeline.ForceBuildPath},
+			}
 		}
 	} else {
-		fakeChangeEvent = &pipeline.ChangeEvent{}
+		fakeChangeEvent = &pipeline.ChangeEvent{
+			Paths: []string{pipeline.ForceBuildPath},
+		}
 	}
 
 	log.Println("starting pipeline...")

--- a/internal/pipeline/build.go
+++ b/internal/pipeline/build.go
@@ -13,6 +13,8 @@ import (
 	"github.com/mokiat/gocrane/internal/project"
 )
 
+const ForceBuildPath = "/gocrane/fake/forced/build"
+
 func Build(
 	ctx context.Context,
 	mainDir string,
@@ -36,6 +38,7 @@ func Build(
 	}()
 
 	builder := project.NewBuilder(mainDir, buildArgs)
+	forceBuildFilter := location.PathFilter(ForceBuildPath)
 
 	return func() error {
 		var lastBinary string
@@ -46,7 +49,8 @@ func Build(
 
 		var changeEvent ChangeEvent
 		for in.Pop(ctx, &changeEvent) {
-			shouldBuild := location.MatchAny(rebuildFilter, changeEvent.Paths)
+			shouldBuild := location.MatchAny(rebuildFilter, changeEvent.Paths) ||
+				location.MatchAny(forceBuildFilter, changeEvent.Paths)
 			shouldRestart := location.MatchAny(restartFilter, changeEvent.Paths)
 
 			// Skip this change event. The changed files are not of relevance.


### PR DESCRIPTION
Currently, if there is a digest mismatch, a build is not triggered. This is because the path list is empty and the builder's matchers no longer consider that as applicable for build.

This change adds a fake path that the build pipeline is watching for and fixes the issue.