### PR TITLE
cmd/example: Use consistent format verbs for log.Fatalf calls

### DIFF
--- a/example/cmd/example/main.go
+++ b/example/cmd/example/main.go
@@ -27,7 +27,7 @@ func main() {
 	log.Println("listening...")
 	go func() {
 		if err := server.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
-			log.Fatalf("http server error: %s\n", err)
+			log.Fatalf("http server error: %v\n", err)
 		}
 	}()
 
@@ -38,7 +38,7 @@ func main() {
 
 	log.Println("shutting down...")
 	if err := server.Shutdown(context.Background()); err != nil {
-		log.Fatalf("failed to shutdown server: %w", err)
+		log.Fatalf("failed to shutdown server: %v\n", err)
 	}
 	log.Println("good bye")
 }

--- a/example/cmd/example/main.go
+++ b/example/cmd/example/main.go
@@ -24,10 +24,10 @@ func main() {
 		Handler: mux,
 	}
 
-	log.Println("listening...")
+	log.Println("Listening...")
 	go func() {
 		if err := server.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
-			log.Fatalf("http server error: %v\n", err)
+			log.Fatalf("Failed to start HTTP server: %v", err)
 		}
 	}()
 
@@ -36,9 +36,9 @@ func main() {
 	defer signal.Stop(sigChan)
 	<-sigChan
 
-	log.Println("shutting down...")
+	log.Println("Shutting down...")
 	if err := server.Shutdown(context.Background()); err != nil {
-		log.Fatalf("failed to shutdown server: %v\n", err)
+		log.Fatalf("Failed to shutdown server: %v", err)
 	}
-	log.Println("good bye")
+	log.Println("Good bye")
 }


### PR DESCRIPTION
The second call to `log.Fatalf` uses the `%w` verb which is not supported by `Fatalf`. Also, it was missing a new line.